### PR TITLE
Fix checkbox in edit.php

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -131,7 +131,7 @@ echo <<<EOL
                 </tr>
                 <tr>
                     <td>Gibt es Cocktails?</td>
-                    <td><input type="radio" name="has_cocktails" value="1" $radio_cocktails_1</td>
+                    <td><input type="radio" name="has_cocktails" value="1" $radio_cocktails_1></td>
                     <td><input type="radio" name="has_cocktails" value="0" $radio_cocktails_0></td>
                     <td><input type="radio" name="has_cocktails" value="2" $radio_cocktails_2></td>
                 </tr>


### PR DESCRIPTION
This PR will (hopefully) fix the weird issue of the missing cocktail field in `edit.php` by adding the missing `>`. :100: 